### PR TITLE
Instrumented test improvement

### DIFF
--- a/app/src/androidTest/java/com/pd/snickers/ChocobarInstrumentedTest.java
+++ b/app/src/androidTest/java/com/pd/snickers/ChocobarInstrumentedTest.java
@@ -46,6 +46,11 @@ public class ChocobarInstrumentedTest {
         assertEquals("Snackbar duration did not match the expected.", Snackbar.LENGTH_SHORT, chocoBar.getDuration());
 
         assertTrue(chocolateLayout.getBackground() instanceof GradientDrawable);
+
+        // and that it can be shown
+        chocoBar.show();
+        assertTrue(chocoBar.isShown());
+        thenWait(1000);
     }
 
     /**
@@ -76,6 +81,11 @@ public class ChocobarInstrumentedTest {
         assertEquals("Expected background color for snackbar layout to be #388E3C.",
                 Color.parseColor("#388E3C"),
                 ((ColorDrawable) chocolateLayout.getBackground()).getColor());
+
+        // and that it can be shown
+        chocoBar.show();
+        assertTrue(chocoBar.isShown());
+        thenWait(1000);
     }
 
     /**
@@ -106,6 +116,11 @@ public class ChocobarInstrumentedTest {
         assertEquals("Expected background color for snackbar layout to be #D50000.",
                 Color.parseColor("#D50000"),
                 ((ColorDrawable) chocolateLayout.getBackground()).getColor());
+
+        // and that it can be shown
+        chocoBar.show();
+        assertTrue(chocoBar.isShown());
+        thenWait(1000);
     }
 
     /**
@@ -136,6 +151,11 @@ public class ChocobarInstrumentedTest {
         assertEquals("Expected background color for snackbar layout to be #e0ffff.",
                 Color.parseColor("#e0ffff"),
                 ((ColorDrawable) chocolateLayout.getBackground()).getColor());
+
+        // and that it can be shown
+        chocoBar.show();
+        assertTrue(chocoBar.isShown());
+        thenWait(1000);
     }
 
     /**
@@ -166,6 +186,11 @@ public class ChocobarInstrumentedTest {
         assertEquals("Expected background color for snackbar layout to be #ffa500.",
                 Color.parseColor("#ffa500"),
                 ((ColorDrawable) chocolateLayout.getBackground()).getColor());
+
+        // and that it can be shown
+        chocoBar.show();
+        assertTrue(chocoBar.isShown());
+        thenWait(1000);
     }
 
     /**
@@ -196,6 +221,11 @@ public class ChocobarInstrumentedTest {
         assertEquals("Expected background color for snackbar layout to be #C5BEBE.",
                 Color.parseColor("#C5BEBE"),
                 ((ColorDrawable) chocolateLayout.getBackground()).getColor());
+
+        // and that it can be shown
+        chocoBar.show();
+        assertTrue(chocoBar.isShown());
+        thenWait(1000);
     }
 
     /**
@@ -226,6 +256,11 @@ public class ChocobarInstrumentedTest {
         assertEquals("Expected background color for snackbar layout to be #C5BEBE.",
                 Color.parseColor("#C5BEBE"),
                 ((ColorDrawable) chocolateLayout.getBackground()).getColor());
+
+        // and that it can be shown
+        chocoBar.show();
+        assertTrue(chocoBar.isShown());
+        thenWait(1000);
     }
 
     /**
@@ -256,6 +291,11 @@ public class ChocobarInstrumentedTest {
         assertEquals("Expected background color for snackbar layout to be #000000.",
                 Color.parseColor("#000000"),
                 ((ColorDrawable) chocolateLayout.getBackground()).getColor());
+
+        // and that it can be shown
+        chocoBar.show();
+        assertTrue(chocoBar.isShown());
+        thenWait(1000);
     }
 
     /**
@@ -286,6 +326,11 @@ public class ChocobarInstrumentedTest {
         assertEquals("Expected background color for snackbar layout to be #E8290B.",
                 Color.parseColor("#E8290B"),
                 ((ColorDrawable) chocolateLayout.getBackground()).getColor());
+
+        // and that it can be shown
+        chocoBar.show();
+        assertTrue(chocoBar.isShown());
+        thenWait(1000);
     }
 
     /**
@@ -316,5 +361,53 @@ public class ChocobarInstrumentedTest {
         assertEquals("Expected background color for snackbar layout to be #000000.",
                 Color.parseColor("#000000"),
                 ((ColorDrawable) chocolateLayout.getBackground()).getColor());
+
+        // and that it can be shown
+        chocoBar.show();
+        assertTrue(chocoBar.isShown());
+        thenWait(1000);
+    }
+
+    /**
+     * Verifies the blocked Chocobar type.
+     */
+    @Test
+    public void testBlockedChocobar() {
+        // Given chocobar builder
+        ChocoBar.Builder chocoBarBuilder = ChocoBar.builder()
+                .setView(activityTestRule.getActivity().getCurrentFocus());
+
+        // When building a blocked Snackbar
+        Snackbar chocoBar = chocoBarBuilder.blocked();
+
+        // Then it matches the expected configuration
+        Snackbar.SnackbarLayout chocolateLayout = (Snackbar.SnackbarLayout) chocoBar.getView();
+
+        TextView snackbarText = (TextView) chocolateLayout.findViewById(R.id.snackbar_text);
+        assertEquals(
+                "Snackbar text did not match the expected.",
+                "BLOCKED",
+                snackbarText.getText());
+
+        assertEquals("Snackbar duration did not match the expected.",
+                Snackbar.LENGTH_SHORT,
+                chocoBar.getDuration());
+
+        assertEquals("Expected background color for snackbar layout to be #E8290B.",
+                Color.parseColor("#E8290B"),
+                ((ColorDrawable) chocolateLayout.getBackground()).getColor());
+
+        // and that it can be shown
+        chocoBar.show();
+        assertTrue(chocoBar.isShown());
+        thenWait(1000);
+    }
+
+    private void thenWait(long milliseconds) {
+        try {
+            Thread.sleep(milliseconds);
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
     }
 }

--- a/app/src/androidTest/java/com/pd/snickers/ExampleInstrumentedTest.java
+++ b/app/src/androidTest/java/com/pd/snickers/ExampleInstrumentedTest.java
@@ -16,11 +16,17 @@ import static org.junit.Assert.*;
  */
 @RunWith(AndroidJUnit4.class)
 public class ExampleInstrumentedTest {
+    /**
+     * Verifies that the package name of the app context returns the expected value.
+     */
     @Test
     public void useAppContext() {
-        // Context of the app under test.
+        // Given Context of the app under test.
         Context appContext = InstrumentationRegistry.getTargetContext();
 
+        // When getting the package name
+
+        // Then it matches the expected value
         assertEquals("com.pd.snickers", appContext.getPackageName());
     }
 }


### PR DESCRIPTION
## Description
Add blocked instrumented test, add show, assert for show, and pause to display the Snackbar for all tests to improve the instrumented tests.

When running the instrumented test, it will automatically cycle and show each ChocoBar for a second now.

## Related issues and discussion
#4

## Screenshots, if any
[Link to video in google drive](https://drive.google.com/file/d/1Tbp9YPh1DO4dVb6D8ng0nVhoGvaE98rW/view?usp=sharing)
(black screen for 5 seconds sorry)
If it hasn't been processed when you view it, download it then open it in your browser.

## Checklist
Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] If you have multiple commits please combine them into one commit by squashing them.

- [x] Read and understood the fun contribution guidelines at CONTRIBUTING.md.
